### PR TITLE
Fixed MS SQL GUID scrambling upon decode

### DIFF
--- a/types.go
+++ b/types.go
@@ -829,6 +829,9 @@ func decodeMoney4(buf []byte) []byte {
 func decodeGuid(buf []byte) []byte {
 	res := make([]byte, 16)
 	copy(res, buf)
+	res[0], res[1], res[2], res[3] = res[3], res[2], res[1], res[0]
+	res[4], res[5] = res[5], res[4]
+	res[6], res[7] = res[7], res[6]
 	return res
 }
 


### PR DESCRIPTION
When grabbing the GUID from the MS SQL database, the first half of the GUID becomes scrambled, due to the parser mixing up the Little Endian and Big Endian data types, and this is due to the way Microsoft handles GUIDs.

The proposed pull request correctly swaps the byte order by implementing the fix proposed in https://github.com/denisenkom/go-mssqldb/issues/56

Microsoft SQL Server 2014 (SP3) (KB4022619) - 12.0.6024.0 (X64)
Sep 7 2018 01:37:51
Copyright (c) Microsoft Corporation
Enterprise Edition (64-bit) on Windows NT 6.3 (Build 9600: ) (Hypervisor)

Client side operating system is Windows 10 (VM Parallels)